### PR TITLE
First pass at coord_loop

### DIFF
--- a/R/coord-loop.R
+++ b/R/coord-loop.R
@@ -22,10 +22,6 @@ coord_loop <- function(
   clip = "on",
   coord = coord_cartesian()
 ) {
-  # Start by assuming time = "x"
-  # TODO: Generalise to vertical looping with time = "y"
-  stopifnot(time == "x")
-
   ggplot2::ggproto(
     NULL,
     CoordLoop(coord),
@@ -48,163 +44,107 @@ CoordLoop <- function(coord) {
   ggplot2::ggproto(
     "CoordLoop",
     coord,
-    setup_layout = function(layout, params) coord$setup_layout(layout, params),
+
+    setup_layout = function(layout, params) {
+      coord$setup_layout(layout, params)
+    },
+
     setup_data = function(data, params) {
       coord$setup_data(data, params)
     },
-    render_fg = function(panel_params, theme) {
-      fg <- coord$render_fg(panel_params, theme)
-      fg
+
+    setup_params = function(self, data) {
+      ggproto_parent(coord, self)$setup_params(data)
     },
-    render_bg = function(self, panel_params, theme) {
-      bg <- ggproto_parent(coord, self)$render_bg(panel_params, theme)
-      bg
+
+    setup_panel_params = function(self, scale_x, scale_y, params = list()) {
+      # We need to adjust the panel parameters so that the scale is zoomed in
+      # on the first region (which we will translate all other regions onto in draw_panel).
+
+      # Calculate the panel parmeters as normal (without cutting)
+      # Need to do this so that user-defined limits, scale limits, expand, etc
+      # are all appropriately taken into account
+      uncut_params <- ggproto_parent(coord, self)$setup_panel_params(scale_x, scale_y, params)
+
+      # Determine the cutpoints where we will loop
+      time_cuts <- cut_axis_time(uncut_params, self$time, self$time_loop)
+
+      # Recalculate the panel parameters zoomed in on the first region.
+      # Doing it this way should apply expand settings, etc, again.
+      self$limits[[self$time]] <- time_cuts[c(1,2)]   # comment out this line to disable zooming (for debug)
+      cut_params <- ggproto_parent(coord, self)$setup_panel_params(scale_x, scale_y, params)
+      cut_params$time_cuts <- time_cuts
+      cut_params
     },
+
     draw_panel = function(self, panel, params, theme) {
       if (!ggplot2::check_device("clippingPaths")) {
         stop("Looped coordinates requires R v4.2.0 or higher.")
       }
 
-      # Get time range from x-axis for cutting
-      tx <- params$x$get_transformation()
-      time_range <- tx$inverse(params$x$limits)
-      time_cuts <- unique(c(
-        seq(time_range[1], time_range[2], by = self$time_loop),
-        time_range[2]
-      ))
-      plot_cuts <- rescale(tx$transform(time_cuts), c(0, 1))
+      # Get cutpoints along the axis for dividing the panel grob into regions
+      cuts <- params[[self$time]]$rescale(params$time_cuts)
+      origin <- cuts[[1]]
 
-      widths <- diff(plot_cuts)
-      centers <- rowMeans(embed(plot_cuts, 2))
-
-      panel <- ggproto_parent(coord, self)$draw_panel(panel, params, theme)
-      # Draw the full poanel
-      plot.new()
-      grid.draw(panel)
-
-      src <- circleGrob(3:4 / 5, r = .3, gp = gpar(col = NA, fill = 2))
-
-      # Draw an artibtrary region
-      plot.new()
-      grid.draw(src)
-      plot.new()
-      grid.draw(groupGrob(groupGrob(src), "dest.in", panel))
-
-      z <- groupGrob(
-        groupGrob(rectGrob(x = centers[1], width = widths[1])),
-        "dest.in",
-        panel
+      # Translate and superimpose the panel grob on itself repeatedly.
+      # I attempted to use defineGrob() + useGrob() here to improve efficiency
+      # (since theoretically it allows efficient repitition of a single grob
+      # drawn off-screen), I couldn't figure out how to make the grob defined
+      # by defineGrob() not be clipped by the first region it would theoretically
+      # have been drawn into given where it is in the grob tree, which meant
+      # it was always getting clipped. So I stuck to just repeatedly re-drawing
+      # the same grob.
+      .viewport = switch(self$time,
+        x = viewport,
+        y = function(x, y, ...) viewport(y = x, x = y, ...)
       )
-
-      grid.draw(useGrob(z, viewportTranslate))
-      z$src
-
-      grid.draw(rectGrob(x = centers[1], width = widths[1]))
-
-      grid.draw(
-        groupGrob(
-          groupGrob(rectGrob(x = centers[1], width = widths[1])),
-          "dest.in",
-          panel
-        ),
-      )
-      grid.draw(
-        groupGrob(
-          panel,
-          vp = viewport(
-            x = centers[1],
-            width = widths[1],
-            xscale = c(0, widths[1])
+      panel_grob <- inject(grobTree(!!!panel))
+      translated_panels <- lapply(
+        head(cuts, -1),
+        function(x) grobTree(
+          panel_grob,
+          vp = .viewport(
+            unit(origin - x, "npc"),
+            unit(0, "npc"),
+            just = c(0, 0)
+            # Could clip here (as below) but that will clip inside the space
+            # added by `expand = `, so probably better not to
+            # clip = rectGrob(unit(x, "npc"), just = 0, width = unit(1, "npc"))
           )
         )
       )
 
-      cal_grobs <- .mapply(
-        function(x, w) {
-          groupGrob(groupGrob(rectGrob(x = x, width = w)), "dest.in", panel)
-        },
-        list(centers, widths),
-        NULL
-      )
+      # # Uncomment for debug info --- region boundaries and centers
+      # widths <- diff(cuts)
+      # centers <- rowMeans(embed(cuts, 2))
+      # translated_panels <- c(
+      #   translated_panels,
+      #   list(
+      #     rectGrob(x = unit(centers, "npc"), y = unit(rep(0.5, length(centers)), "npc"), width = unit(widths, "npc"), gp = gpar(col = "red", fill = NA)),
+      #     pointsGrob(x = unit(centers, "npc"), y = unit(rep(0.5, length(centers)), "npc"), gp = gpar(col = "red"))
+      #   )
+      # )
 
-      cal_grobs
-      gt <- gtable(widths = unit(1, "null"), heights = unit(c(1, 1), "null"))
-      gt <- gtable_add_grob(gt, cal_grobs[1], 1, 1)
-      gt <- gtable_add_grob(gt, cal_grobs[2], 2, 1)
-      grid.draw(gt)
-
-      plot.new()
-      grid.group(panel)
-
-      r <- rectGrob(
-        1 / 3,
-        2 / 3,
-        width = .5,
-        height = .5,
-        gp = gpar(fill = "black")
-      )
-      c <- circleGrob(2 / 3, 1 / 3, r = .3, gp = gpar(fill = "black"))
-      gt <- gTree(children = gList(r, c))
-      grid.group(gt)
-      grid.group(c, "dest.out", r)
-      plot.new()
-      mask <- rectGrob(gp = gpar(col = NA, fill = rgb(0, 0, 0, .5)))
-      grid.text("background")
-      pushViewport(viewport(mask = mask))
-
-      gg <- ggplotGrob(p)
-      grid.group(gg)
-
-      plot.new()
-      src <- circleGrob(3:4 / 5, r = .3, gp = gpar(col = NA, fill = 2))
-      dst <- circleGrob(1:2 / 5, r = .3, gp = gpar(col = NA, fill = 3))
-      grid.draw(groupGrob(groupGrob(src), "dest.in", panel))
-
-      g <- gtable::gtable(
-        widths = rep(grid::grobWidth(panel), 2),
-        heights = rep(grid::grobHeight(panel), 3)
-      )
-
-      return(gtable::gtable_add_grob(
-        g,
-        rep(list(panel), 4),
-        c(1:2, 1:2),
-        c(1:2, 2:1) #rep(1:2, each = 3), rep(1:3, each = 2)
-      ))
-      return(gtable::gtable_add_grob(
-        g,
-        rep(list(panel), 6),
-        rep(1:2, each = 3),
-        rep(1:3, each = 2)
-      ))
-      # return(panel)
-
-      nrow <- 3
-      ncol <- 2
-      make_panels <- function(i, panel) {
-        row <- (i - 1) %/% ncol + 1
-        col <- (i - 1) %% ncol + 1
-        x_pos <- (col - 0.5) / ncol # Normalised x-coordinate
-        y_pos <- 1 - (row - 0.5) / nrow # Normalised y-coordinate (inverted y)
-
-        gTree(
-          children = gList(panel),
-          vp = viewport(
-            x = x_pos,
-            y = y_pos,
-            width = 1 / ncol,
-            height = 1 / nrow,
-            just = "center"
-          )
-        )
-      }
-
-      gTree(children = do.call(gList, lapply(1:6, make_panels, panel)))
-      # panel
-    },
-
-    setup_params = function(self, data) {
-      ggproto_parent(coord, self)$setup_params(data)
+      ggproto_parent(coord, self)$draw_panel(translated_panels, params, theme)
     }
   )
+}
+
+
+#' Get time cutpoints along a positional axis
+#' @param params Panel params, e.g. as returned by `Coord$setup_panel_params()`
+#' and passed to `Coord$draw_panel(params = ...)`
+#' @param axis Axis to cut (`"x"` or `"y"`).
+#' @param by Duration to cut by
+#' @returns vector of time cutpoints
+#' @noRd
+cut_axis_time <- function(params, axis, by) {
+  trans <- params[[axis]]$get_transformation()
+  range <- params[[axis]]$limits
+  time_range <- trans$inverse(range)
+  time_cuts <- unique(c(
+    seq(time_range[1], time_range[2], by = by),
+    time_range[2]
+  ))
+  time_cuts
 }


### PR DESCRIPTION
@mitchelloharawild I think this is a roughly working first draft of `coord_loop()`.

Demo:

```r
x <- 1:100
p <- tibble(
  time = as.POSIXct("2025-08-15 03:00:00") + x*3600,
  sin = sin(x/pi/24*20) + x/100,
  g = rep(c("a","b"), 50),
  day = factor(lubridate::day(time))
) |>
  ggplot(aes(x = time, y = sin, 
    color = day,
    group = NA)) +
  geom_path() +
  facet_grid(g ~ .)

p + coord_loop(time_loop = "24 hours")
```
<img width="1575" height="973" alt="image" src="https://github.com/user-attachments/assets/8559cb6e-453d-441f-9717-9cdaf357c803" />

It could be odd in some cases in that the user has to make sure the x axis labels are sensible (e.g. above they might make more sense without the date attached) but I'm not sure there's a good way to get `coord` to do that.

`time = "y"` should also work.

This doesn't:

```r
p <- as_tsibble(USAccDeaths) |>
    ggplot(aes(x = index, y = value)) +
    geom_line()

p + coord_loop(time_loop = "year")
## Error in `bad_by()`:
## ! `by` only takes a numeric.
## Run `rlang::last_trace()` to see where the error occurred.
```

I think that's down to the `cut_axis_time()` helper not handling fancy time types. I imagine you could fix that faster than I could.